### PR TITLE
Forgot password on new/missing accounts

### DIFF
--- a/src/Swetugg.Web/App_Start/IdentityConfig.cs
+++ b/src/Swetugg.Web/App_Start/IdentityConfig.cs
@@ -25,7 +25,7 @@ namespace Swetugg.Web
             return configSendGridasync(message);
         }
 
-        private Task configSendGridasync(IdentityMessage message)
+        private async Task configSendGridasync(IdentityMessage message)
         {
             var myMessage = new SendGridMessage();
             myMessage.AddTo(message.Destination);
@@ -44,21 +44,13 @@ namespace Swetugg.Web
             var transportWeb = new SendGrid.Web(credentials);
 
             // Send the email.
-            if (transportWeb != null)
+            try
             {
-                try
-                {
-                    transportWeb.DeliverAsync(myMessage).Wait();
-                }
-                catch (Exception)
-                {
-                    //
-                }
-                return Task.FromResult(0);
+                await transportWeb.DeliverAsync(myMessage);
             }
-            else
+            catch (Exception)
             {
-                return Task.FromResult(0);
+                //
             }
         }
         

--- a/src/Swetugg.Web/Controllers/AccountController.cs
+++ b/src/Swetugg.Web/Controllers/AccountController.cs
@@ -224,6 +224,34 @@ namespace Swetugg.Web.Controllers
                 var user = await UserManager.FindByNameAsync(model.Email);
                 if (user == null || !(await UserManager.IsEmailConfirmedAsync(user.Id)))
                 {
+                    //Notify unknown user that password reset attempt was made
+                    if (_useSendGrid)
+                    {
+                        await UserManager.EmailService.SendAsync(
+                            new IdentityMessage
+                            {
+                                Destination = model.Email,
+                                Subject = "Reset password",
+                                Body = string.Format(
+                                    @"Hi,<br/>
+<br/>
+Someone as tried to reset your password for email {0} on our site.<br/>
+<br/>
+Unfortunately we can’t find any user with that email in our database, if you’d like to register a new account please use the link below:<br/>
+{1}
+",
+                                    model.Email,
+                                    Url.Action(
+                                        protocol: Request.Url.Scheme,
+                                        actionName: "Register",
+                                        controllerName: "Account",
+                                        routeValues: new {}
+                                        )
+                                    )
+                            }
+                            );
+                    }
+
                     // Don't reveal that the user does not exist or is not confirmed
                     return View("ForgotPasswordConfirmation");
                 }


### PR DESCRIPTION
* This fixes issue #39 by also notifying new users if they try to do a password reset.
* It also fixes and potential deadlock by async issue in the `IdentityConfig` SendGrid setup.