### PR TITLE
Remove caching of null

### DIFF
--- a/src/Swetugg.Web/Services/CachedConferenceService.cs
+++ b/src/Swetugg.Web/Services/CachedConferenceService.cs
@@ -36,11 +36,14 @@ namespace Swetugg.Web.Services
             if (cached == null)
             {
                 cached = fetch();
-                httpCache.Add(key, cached, 
-                    null, 
-                    DateTime.Now.AddMinutes(MinutesToCache), 
-                    Cache.NoSlidingExpiration,
-                    CacheItemPriority.Default, null);
+                if (cached != null)
+                {
+                    httpCache.Add(key, cached,
+                        null,
+                        DateTime.Now.AddMinutes(MinutesToCache),
+                        Cache.NoSlidingExpiration,
+                        CacheItemPriority.Default, null);
+                }
             }
             return cached;
         }


### PR DESCRIPTION
Asp.Net doesn't allow you to cache null, so no need to cache value if null.