### PR TITLE
Added configurable db init strategy

### DIFF
--- a/src/Swetugg.Web/Models/ApplicationDbContext.cs
+++ b/src/Swetugg.Web/Models/ApplicationDbContext.cs
@@ -1,7 +1,7 @@
-﻿using System;
+﻿using System.Configuration;
 using System.Data.Entity;
 using Microsoft.AspNet.Identity.EntityFramework;
-using Swetugg.Web.Migrations;
+using Configuration = Swetugg.Web.Migrations.Configuration;
 
 namespace Swetugg.Web.Models
 {
@@ -27,8 +27,26 @@ namespace Swetugg.Web.Models
 
 		public static ApplicationDbContext Create()
 		{
-            Database.SetInitializer(new NullDatabaseInitializer<ApplicationDbContext>());
-            // Database.SetInitializer(new MigrateDatabaseToLatestVersion<ApplicationDbContext, Configuration>());
+            IDatabaseInitializer<ApplicationDbContext> strategy;
+            switch (ConfigurationManager.AppSettings["Database_Initialize_Strategy"])
+            {
+                case "CreateDatabaseIfNotExists":
+                    strategy = new CreateDatabaseIfNotExists<ApplicationDbContext>();
+                    break;
+                case "DropCreateDatabaseAlways":
+                    strategy = new DropCreateDatabaseAlways<ApplicationDbContext>();
+                    break;
+                case "DropCreateDatabaseIfModelChanges":
+                    strategy = new DropCreateDatabaseIfModelChanges<ApplicationDbContext>();
+                    break;
+                case "MigrateDatabaseToLatestVersion":
+                    strategy = new MigrateDatabaseToLatestVersion<ApplicationDbContext, Configuration>();
+                    break;
+                default:
+                    strategy = new NullDatabaseInitializer<ApplicationDbContext>();
+                    break;
+            }
+            Database.SetInitializer(strategy);
             return new ApplicationDbContext();
 		}
 

--- a/src/Swetugg.Web/Web.config
+++ b/src/Swetugg.Web/Web.config
@@ -50,6 +50,17 @@
     <add key="CachedConferenceService.MinutesToCache" value="5" />
 
     <add key="ApplicationInsights.InstrumentationKey" value="" />
+
+    <!--
+      Database initalize strategy (default/unknown = NullDatabaseInitializer)
+      Valid options are:
+        CreateDatabaseIfNotExists
+        DropCreateDatabaseAlways
+        MigrateDatabaseToLatestVersion
+        NullDatabaseInitializer
+    -->
+    <add key="Database_Initialize_Strategy" value="CreateDatabaseIfNotExists" />
+
   </appSettings>
   <system.web>
     <authentication mode="None" />


### PR DESCRIPTION
This fixes #46 by adding an optional `web.config` setting for databse initalize strategy,
defaulting to `NullDatabaseInitializer`, but `CreateDatabaseIfNotExists` specified in
repo `web.config` to work as described in `README.md`
Current supported strategies are:
* CreateDatabaseIfNotExists
* DropCreateDatabaseAlways
* MigrateDatabaseToLatestVersion
* NullDatabaseInitializer