### PR TITLE
Translate tweet to English&fix max length

### DIFF
--- a/src/Swetugg.Web/Areas/Swetugg2018/Views/Conference/Speaker.cshtml
+++ b/src/Swetugg.Web/Areas/Swetugg2018/Views/Conference/Speaker.cshtml
@@ -41,12 +41,17 @@
                 <div class="row">
                     <div class="col-lg-8 col-lg-offset-2">
                         @{
-                var nameText = "Missa inte \"" + session.Name + "\"";
+                var nameText = "Don't miss \"{0}\"";
                 if (!string.IsNullOrEmpty(Model.Twitter))
                 {
-                    nameText = nameText + " med @" + Model.Twitter;
+                    nameText = nameText + " with @" + Model.Twitter;
                 }
-                var twitterText = nameText + " på @Swetugg 2018!";
+                var twitterText = nameText + " at @Swetugg 2018!";
+                var avail = 119 - twitterText.Length;
+                twitterText = string.Format(
+                    twitterText,
+                    (session.Name.Length <= avail) ? session.Name : session.Name.Substring(0, avail - 3) + "..."
+                    );
                 var linkUrl = Url.Action("Speaker", "Conference", null, Request.Url.Scheme) + "#" + session.Slug;
                         }
                         <a href="#@session.Slug">


### PR DESCRIPTION
Everything else on the page is in English so probably this should be too.

Also truncates the session name if exceeds the twitter limit.

So below
![image](https://user-images.githubusercontent.com/1647294/31862292-9c839730-b73b-11e7-99e9-f364eb14d667.png)
becomes
![image](https://user-images.githubusercontent.com/1647294/31862304-c716d728-b73b-11e7-9f7b-04c3c3066fe9.png)
